### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -478,11 +478,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1780788893,
-        "narHash": "sha256-/4hokOLtU9s1R0IvGEbyOoRp6YpUgMGqLg6JJni5Uxc=",
+        "lastModified": 1780860453,
+        "narHash": "sha256-6JFkIPHmg31COQxmlK/YG8HuSGOdZuNkP91ntMiWCDs=",
         "owner": "p15r",
         "repo": "nix-tresorit",
-        "rev": "24396eefd6371ca172a1877e68987bdff7da1795",
+        "rev": "8e4eca4fed1ffdd3e588a7f2db805eb960a29388",
         "type": "github"
       },
       "original": {
@@ -690,11 +690,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1780203844,
-        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
+        "lastModified": 1780734595,
+        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
+        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
         "type": "github"
       },
       "original": {
@@ -833,11 +833,11 @@
         "systems": "systems_4"
       },
       "locked": {
-        "lastModified": 1780422259,
-        "narHash": "sha256-dWGk4SEdI189kQW5cE4Uo1Mc+P+kQEdgMcyMgTtmQOA=",
+        "lastModified": 1780857688,
+        "narHash": "sha256-e4E6M6erJIus5Cm/A4faaaTuUfof1uvcviAPSh7tmLU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "8414bbf2fcc7bc0a22c675e498e3c7365c1aec0a",
+        "rev": "aad629e8261f219b0a5b3a2189b09d65216a0983",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake dependency update.

Flake lock file updates:

• Updated input 'nix-tresorit':
    'github:p15r/nix-tresorit/24396ee' (2026-06-06)
  → 'github:p15r/nix-tresorit/8e4eca4' (2026-06-07)
• Updated input 'nix-tresorit/nixpkgs':
    'github:nixos/nixpkgs/b51242d' (2026-05-31)
  → 'github:nixos/nixpkgs/9b69646' (2026-06-06)
• Updated input 'spicetify-nix':
    'github:Gerg-L/spicetify-nix/8414bbf' (2026-06-02)
  → 'github:Gerg-L/spicetify-nix/aad629e' (2026-06-07)