### PR TITLE
niri: theme background + overview backdrop from stylix

### DIFF
--- a/home/linux/niri/default.nix
+++ b/home/linux/niri/default.nix
@@ -81,7 +81,13 @@ in
               inactive-color "#${c.base02}"
           }
           border { off; }
+          // Empty-workspace background (stylix image = null, so nothing else
+          // fills it — without this niri falls back to its default gray).
+          background-color "#${c.base00}"
       }
+
+      // Overview / inter-workspace backdrop, themed from stylix.
+      overview { backdrop-color "#${c.base01}"; }
 
       prefer-no-csd
       screenshot-path "~/Pictures/Screenshots/Screenshot-%Y-%m-%d-%H-%M-%S.png"


### PR DESCRIPTION
stylix ships no niri target, so niri's color surfaces are wired by hand. focus-ring and the mono font already came from stylix; the two remaining color surfaces were left unset and fell back to niri's default gray (`image = null`, so no wallpaper covers them):

- `layout { background-color }` → `base00` (empty-workspace background)
- `overview { backdrop-color }` → `base01` (overview / inter-workspace backdrop)

Both driven from `config.lib.stylix.colors`. Verified with `niri validate` (builds `config.kdl` → `config is valid`); confirmed hex substitutes (`#fdf6e3` / `#f4f0d9`).