### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -755,11 +755,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785963532,
-        "narHash": "sha256-ruNBSwUVmmOqynTXy7PXymD2WaUWr2LjyJKi9vng1KA=",
+        "lastModified": 1785972131,
+        "narHash": "sha256-oZx9Z3CeCUfsOGEyvIuBBuVjL3/ESa6/Evuj+gceASI=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "ebf6fc07a11d5759e1bd79228a8802dae08d5628",
+        "rev": "24470e52a537f7a4d08be681b95b3a1891fc1bfa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake dependency update.

Flake lock file updates:

• Updated input 'opencode':
    'github:anomalyco/opencode/ebf6fc0' (2026-08-05)
  → 'github:anomalyco/opencode/24470e5' (2026-08-05)