### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1786748620,
-        "narHash": "sha256-K+sJmUXFksrB7pLvrcv8jIDGKxN52QtV1sIKXhT8MZo=",
+        "lastModified": 1787000716,
+        "narHash": "sha256-OvS7Bs6A2b7GsqcLdvWJ8HWn6ppj4wVbH0J8olARNA8=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "fd727a3f341b079ba5387b770c5caef86bdae3e6",
+        "rev": "2a8a4d8d8f3d5d49cede737a0df1b49992ffb7e5",
         "type": "github"
       },
       "original": {
@@ -535,11 +535,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786593342,
-        "narHash": "sha256-smTKQXMLLStzc8zJevMCckbk3My7SvbbLmPYZUJJKW4=",
+        "lastModified": 1786963906,
+        "narHash": "sha256-3tkeMWSvHPo3tYljfXbPC/TgknikU1GvdVr/DkdfvE0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b5e5b7a6631f065bf6908986990b37d845f847f",
+        "rev": "f4b6996c4e8b9ee06ce147ec344c885f51071b14",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786719841,
-        "narHash": "sha256-QcpQOT0NQEFkI77t+YXPZqDJc35iIodG7zinieOwFUg=",
+        "lastModified": 1786963906,
+        "narHash": "sha256-3tkeMWSvHPo3tYljfXbPC/TgknikU1GvdVr/DkdfvE0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8be7bd0c83f12e2e3bbba07c9044d6fed9e66f7f",
+        "rev": "f4b6996c4e8b9ee06ce147ec344c885f51071b14",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1786711500,
-        "narHash": "sha256-QvnceIGTBeDvDd9oCn+GvdsnkquliuwbVgpiRH68qaQ=",
+        "lastModified": 1786943417,
+        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02e08985a27c65ffd33d434eeb2e660a2e4dc84d",
+        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
         "type": "github"
       },
       "original": {
@@ -737,11 +737,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786917525,
-        "narHash": "sha256-v/uaPa4ZlU4Mcb5bUJcuGkYs5VaxiyMI116dbwjp9Bg=",
+        "lastModified": 1786994735,
+        "narHash": "sha256-JxSdNCqTKVBl81Ch15B/q83iIU1yY9X8LtdAt43PiIw=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "1c965451b537e1af4bff12c163200f762a6a0364",
+        "rev": "65c35977bd564e23c0e9cf124b3e3e3b9308e9e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake dependency update.

Flake lock file updates:

• Updated input 'claude-code':
    'github:sadjow/claude-code-nix/fd727a3' (2026-08-14)
  → 'github:sadjow/claude-code-nix/2a8a4d8' (2026-08-17)
• Updated input 'claude-code/nixpkgs':
    'github:NixOS/nixpkgs/6b5e5b7' (2026-08-13)
  → 'github:NixOS/nixpkgs/f4b6996' (2026-08-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/02e0898' (2026-08-14)
  → 'github:nixos/nixpkgs/0dd31db' (2026-08-17)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/8be7bd0' (2026-08-14)
  → 'github:nixos/nixpkgs/f4b6996' (2026-08-17)
• Updated input 'opencode':
    'github:anomalyco/opencode/1c96545' (2026-08-16)
  → 'github:anomalyco/opencode/65c3597' (2026-08-17)