### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1787000716,
-        "narHash": "sha256-OvS7Bs6A2b7GsqcLdvWJ8HWn6ppj4wVbH0J8olARNA8=",
+        "lastModified": 1787087042,
+        "narHash": "sha256-xt4hV5if4WpNCfwtT0RW3oze/bJ534LUR0KLOw2cbNE=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "2a8a4d8d8f3d5d49cede737a0df1b49992ffb7e5",
+        "rev": "3d6821aaa0a0a06cc4b60dcd00d05756de68ba50",
         "type": "github"
       },
       "original": {
@@ -535,11 +535,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786963906,
-        "narHash": "sha256-3tkeMWSvHPo3tYljfXbPC/TgknikU1GvdVr/DkdfvE0=",
+        "lastModified": 1787052956,
+        "narHash": "sha256-fZt7Au28AduGpt7vRfIOcpsHKJ+9cEnuQ2NdWuh0KVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4b6996c4e8b9ee06ce147ec344c885f51071b14",
+        "rev": "b47ad65d73ab65ded9ab408fe558866d71defee8",
         "type": "github"
       },
       "original": {
@@ -582,11 +582,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1786963906,
-        "narHash": "sha256-3tkeMWSvHPo3tYljfXbPC/TgknikU1GvdVr/DkdfvE0=",
+        "lastModified": 1787052956,
+        "narHash": "sha256-fZt7Au28AduGpt7vRfIOcpsHKJ+9cEnuQ2NdWuh0KVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f4b6996c4e8b9ee06ce147ec344c885f51071b14",
+        "rev": "b47ad65d73ab65ded9ab408fe558866d71defee8",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1786943417,
-        "narHash": "sha256-b4qgjdFtlz5TAZ1Hi7DFJeqX3sjaDUnrwr9OO+O1rM0=",
+        "lastModified": 1787042014,
+        "narHash": "sha256-lgnV/xeEatfEnPZG0RrXS0fhcr63p3tsVvL1GdaVkJQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0dd31db7e6dbf9ce05697c4545f6fe01accec994",
+        "rev": "c69ae8fb8faeb3472fd11234ba55a70ac3601f9b",
         "type": "github"
       },
       "original": {
@@ -737,11 +737,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786994735,
-        "narHash": "sha256-JxSdNCqTKVBl81Ch15B/q83iIU1yY9X8LtdAt43PiIw=",
+        "lastModified": 1787093999,
+        "narHash": "sha256-XlaDTxSVyVCAuOw64pDT5MgVONp/1XReM1n4vuyLaKs=",
         "owner": "anomalyco",
         "repo": "opencode",
-        "rev": "65c35977bd564e23c0e9cf124b3e3e3b9308e9e8",
+        "rev": "8b65fa2ef6372fde3109736a42e7f3aeb87f3a4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automated flake dependency update.

Flake lock file updates:

• Updated input 'claude-code':
    'github:sadjow/claude-code-nix/2a8a4d8' (2026-08-17)
  → 'github:sadjow/claude-code-nix/3d6821a' (2026-08-18)
• Updated input 'claude-code/nixpkgs':
    'github:NixOS/nixpkgs/f4b6996' (2026-08-17)
  → 'github:NixOS/nixpkgs/b47ad65' (2026-08-18)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0dd31db' (2026-08-17)
  → 'github:nixos/nixpkgs/c69ae8f' (2026-08-18)
• Updated input 'nixpkgs-unstable':
    'github:nixos/nixpkgs/f4b6996' (2026-08-17)
  → 'github:nixos/nixpkgs/b47ad65' (2026-08-18)
• Updated input 'opencode':
    'github:anomalyco/opencode/65c3597' (2026-08-17)
  → 'github:anomalyco/opencode/8b65fa2' (2026-08-18)